### PR TITLE
Add libmysqlservices.a for mysql56u-devel

### DIFF
--- a/SPECS/mysql56u.spec
+++ b/SPECS/mysql56u.spec
@@ -476,7 +476,6 @@ ln -s ../../../../../bin/my_safe_process %{buildroot}%{_datadir}/mysql-test/lib/
 # not needed in rpm package
 rm -f %{buildroot}%{_bindir}/mysqlaccess.conf
 rm -f %{buildroot}%{_bindir}/mysql_embedded
-rm -f %{buildroot}%{_libdir}/mysql/*.a
 rm -f %{buildroot}%{_datadir}/%{name}/binary-configure
 rm -f %{buildroot}%{_datadir}/%{name}/magic
 rm -f %{buildroot}%{_datadir}/%{name}/mysql.server
@@ -817,6 +816,8 @@ fi
 /usr/share/aclocal/mysql.m4
 %{_libdir}/mysql/libmysqlclient.so
 %{_libdir}/mysql/libmysqlclient_r.so
+%{_libdir}/mysql/libmysqlclient.a
+%{_libdir}/mysql/libmysqlclient_r.a
 %{_libdir}/mysql/libmysqlservices.a
 
 %files embedded


### PR DESCRIPTION
It is necessary to be installed `libmysqlservices.a` on adding custom plugins.  
I have add the line to `SPECS/mysql56u.spec` same as oracle package like below.

```
$ less ~/rpmbuild/SPECS/mysql.5.6.14.spec
%files -n MySQL-devel%{product_suffix} -f optional-files-devel
%defattr(-, root, root, 0755)
%doc %attr(644, root, man) %{_mandir}/man1/comp_err.1*
%doc %attr(644, root, man) %{_mandir}/man1/mysql_config.1*
%attr(755, root, root) %{_bindir}/mysql_config
%dir %attr(755, root, root) %{_includedir}/mysql
%dir %attr(755, root, root) %{_libdir}/mysql
%{_includedir}/mysql/*
%{_datadir}/aclocal/mysql.m4
%{_libdir}/mysql/libmysqlclient.a
%{_libdir}/mysql/libmysqlclient_r.a
%{_libdir}/mysql/libmysqlservices.a
```

Please let me know if have to use the launchpad instead of GitHub.
ref. http://iuscommunity.org/pages/ContributingToIUS.html
